### PR TITLE
Initialize world_size for animals

### DIFF
--- a/simulation/animals.py
+++ b/simulation/animals.py
@@ -154,6 +154,9 @@ class AnimalSystem:
         
         # Store world reference
         self.world = world
+
+        # Determine size of the simulation world
+        self.world_size = (self.world.environment.width, self.world.environment.height)
         
         # Initialize animal populations
         logger.info("Setting up animal populations...")


### PR DESCRIPTION
## Summary
- calculate `self.world_size` in `AnimalSystem.__init__`
- use environment width and height before animals are initialized

## Testing
- `python -m compileall simulation/animals.py`
- `python -m compileall simulation` *(fails: SyntaxError in simulation/marine.py)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841811e114c832d914e52cb7a2838ee