### PR TITLE
Add cognition system initialization

### DIFF
--- a/simulation/world.py
+++ b/simulation/world.py
@@ -164,6 +164,11 @@ class World:
         
         # Initialize agents
         self.agents.initialize_agents()
+
+        # Initialize cognition systems for existing agents
+        for agent_id in self.agents.agents:
+            if agent_id not in self.cognition_systems:
+                self.cognition_systems[agent_id] = AgentCognition(agent_id)
         
         # Initialize society
         self.society.initialize_society()
@@ -270,9 +275,12 @@ class World:
         for _ in range(count):
             # Get spawn location
             lon, lat = self.get_spawn_location()
-            
+
             # Create agent through agent system
-            self.agents.create_agent(lon, lat)
+            agent_id = self.agents.create_agent(lon, lat)
+
+            # Initialize cognition system for the new agent
+            self.cognition_systems[agent_id] = AgentCognition(agent_id)
             
         self.logger.info("Initial agent spawning complete")
         
@@ -295,6 +303,10 @@ class World:
             latitude=lat,
             parent_id=parent_id
         )
+
+        if child_id:
+            # Initialize cognition system for the child
+            self.cognition_systems[child_id] = AgentCognition(child_id)
         
         if child_id:
             self.logger.info(f"Spawned child agent {child_id} from parent {parent_id}")
@@ -841,7 +853,7 @@ class World:
         if agent is None:
             return {}
 
-        cognition = self.cognition_systems[agent_id]
+        cognition = self.cognition_systems.get(agent_id)
         
         # Get agent's social group
         social_group = None


### PR DESCRIPTION
## Summary
- create a cognition system whenever an agent is initialized or spawned
- guard against missing cognition systems when building agent JSON

## Testing
- `python -m py_compile simulation/world.py`
- `pytest -q`
- `find simulation -name '*.py' | while read f; do python -m py_compile "$f" || exit 1; done` *(fails: source code string cannot contain null bytes)*

------
https://chatgpt.com/codex/tasks/task_e_6841811f2c90832d9485b09935f3b8ea