### PR TITLE
Fix engine startup and add tick logging

### DIFF
--- a/simulation/world.py
+++ b/simulation/world.py
@@ -299,6 +299,11 @@ class World:
         self.simulation_time += 1
         self.current_tick += 1
         self.game_time += timedelta(seconds=1)
+
+        # Log the tick number and current game time
+        self.logger.info(
+            f"Tick {self.current_tick}: game time {self.game_time.isoformat()}"
+        )
         
         # Increment day every 86,400 ticks (1 day in game)
         if self.current_tick % 86400 == 0:

--- a/start_simulation.py
+++ b/start_simulation.py
@@ -160,7 +160,10 @@ def main():
         
         # Initialize engine
         engine = SimulationEngine(world, logger)
-        
+
+        # Start the simulation engine so ticks are processed
+        engine.start()
+
         # Start server
         run_server()
         


### PR DESCRIPTION
## Summary
- start the simulation engine in `start_simulation.py`
- log every tick in `world.update`

## Testing
- `python -m py_compile start_simulation.py`
- `python -m py_compile simulation/world.py`
- `flake8 start_simulation.py simulation/world.py`

------
https://chatgpt.com/codex/tasks/task_e_6857f99ab0dc832d89845905d0e07635