### PR TITLE
Fix agent movement and store world state in Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
+Ensure a Redis server is running locally (or set `REDIS_HOST` and `REDIS_PORT`)
+so the simulation can persist world state for the frontend.
+
+The simulation runs at a time scale of **48×**, meaning one in-game day
+passes every 30 minutes of real time.
+
 ## Running the Simulation
 
 1. Start the simulation:

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ isort==5.13.2
 flake8==7.0.0
 eventlet==0.33.3
 setuptools
+redis==5.0.1

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -413,7 +413,7 @@ class AgentSystem:
         terrain_cost = terrain_costs.get(terrain_type, 1.0)
         
         # Slope cost (0-1 scale)
-        slope_cost = 1.0 + (slope * 4.0)  # Steeper slopes cost more energy
+        slope_cost = 1.0 + (slope * 0.1)  # Reduce slope impact to allow movement
         
         return base_cost * terrain_cost * slope_cost
     

--- a/start_simulation.py
+++ b/start_simulation.py
@@ -160,7 +160,10 @@ def main():
         
         # Initialize engine
         engine = SimulationEngine(world, logger)
-        
+
+        # Start the simulation engine so ticks are processed
+        engine.start()
+
         # Start server
         run_server()
         


### PR DESCRIPTION
## Summary
- persist world state to Redis
- read world state from Redis in the API
- reduce slope cost so agents move
- document Redis requirement and time scale
- add redis dependency
- log each simulation tick
- run the simulation engine automatically
- fix missing Tuple import

## Testing
- `python -m py_compile start_simulation.py simulation/world.py simulation/agents.py simulation/routes.py`
- `flake8 start_simulation.py simulation/world.py` *(fails: many style errors)*

------
https://chatgpt.com/codex/tasks/task_e_6857f99ab0dc832d89845905d0e07635